### PR TITLE
iconv args require a character vector

### DIFF
--- a/R/style.R
+++ b/R/style.R
@@ -1,18 +1,18 @@
-.fmtcol <- function(x, big.mark=NA) { if(is.na(big.mark)) as.character(x) else format(x, big.mark=big.mark) } 
+.fmtcol <- function(x, big.mark=NA) { if(is.na(big.mark)) as.character(x) else format(x, big.mark=big.mark) }
 .p <- function(...) paste(..., sep="")
 
 
 .theme <- list(rowid=list(fg="208"),fg=list(int="33",dbl="35",chr="235",na="248"),highlight=list(bg=228))
 
 #.style <- function(x, colsep='│') {
-.pipesep <- iconv("\\u2502","c99","UTF-8")
+.pipesep <- iconv(c("\\u2502","c99","UTF-8"))
 .style <- function(x, colsep=.pipesep, highlight, theme=.theme, maxwidth=getOption("width"), topn=getOption("qkiosk.df.topn",5), nrows=getOption("qkiosk.df.nrows",100)) {
   #if(nrow(x) > nrows && missing(highlight)) {
   #  top <- .style(x[seq(1,topn),], colsep, highlight, maxwidth, topn, nrows)
   #  btm <- .style(x[seq(nrow(x)-topn,nrow(x)),], colsep, highlight, maxwidth, topn, nrows)
   #  x <- paste0(top,"\n...\n\n",btm)
   #  class(x) <- '.qkstyled'
-  #  return(x) 
+  #  return(x)
   #}
   hl <- rep(FALSE, len=nrow(x))
   if( !missing(highlight) ) {
@@ -72,7 +72,7 @@
       if(!is.na(middle) && row==middle)
         styled_rows[[i]][ii+1] <- "  ----\n"
 
-      #cat("rowlen:",nchar(styled_rows[[i]][[ii+1]]),"\n") 
+      #cat("rowlen:",nchar(styled_rows[[i]][[ii+1]]),"\n")
       ii <- ii + 1
     }
     # only show colnames at bottom if displaying non-truncated table that does not wrap


### PR DESCRIPTION
I was receiving a build error as follows:

```
   ** R  
   ** data   
   *** moving datasets to lazyload DB  
   ** byte-compile and prepare package for lazy loading  
   Error in iconv("\\u2502", "c99", "UTF-8") :   

     unsupported conversion from 'c99' to 'UTF-8' 

   Error: unable to load R code in package ‘qkiosk’ 
   Execution halted`
```
   
   Checking the `iconv` documentation, the function requires a character vector, so I merely wrapped the args provided in `c()` and the package now builds.  